### PR TITLE
Expose claims to Authorizator method

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -92,13 +92,13 @@ func (mw *JWTMiddleware) middlewareImpl(writer rest.ResponseWriter, request *res
 
 	id := token.Claims["id"].(string)
 
+	request.Env["REMOTE_USER"] = id
+	request.Env["JWT_PAYLOAD"] = token.Claims
+
 	if !mw.Authorizator(id, request) {
 		mw.unauthorized(writer)
 		return
 	}
-
-	request.Env["REMOTE_USER"] = id
-	request.Env["JWT_PAYLOAD"] = token.Claims
 
 	handler(writer, request)
 }


### PR DESCRIPTION
Allows bypassing expensive DB checks and lookups, while still allowing them if needed.

This allows one to store basic claim data and handle it with the PayloadFunc and Authorization.

See new `TestClaimsDuringAuthorization()` test to demonstrate this.  The actual fix was trivial (just set the `Env` before calling `Authorizator`
