### PR TITLE
ExtractClaims Helper Method to aide in access JWT claims

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -103,6 +103,16 @@ func (mw *JWTMiddleware) middlewareImpl(writer rest.ResponseWriter, request *res
 	handler(writer, request)
 }
 
+// Helper function to extract the JWT claims
+func ExtractClaims(request *rest.Request) map[string]interface{} {
+	if request.Env["JWT_PAYLOAD"] == nil {
+		empty_claims := make(map[string]interface{})
+		return empty_claims
+	}
+	jwt_claims := request.Env["JWT_PAYLOAD"].(map[string]interface{})
+	return jwt_claims
+}
+
 type login struct {
 	Username string `json:"username"`
 	Password string `json:"password"`

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -1,7 +1,6 @@
 package jwt
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -355,13 +354,7 @@ func TestClaimsDuringAuthorization(t *testing.T) {
 			return true
 		},
 		Authorizator: func(userId string, request *rest.Request) bool {
-			// Check that payload is set, output helpful debugging message if not
-			if request.Env["JWT_PAYLOAD"] == nil {
-				log.Println("JWT_PAYLOAD was unset during Authorization!")
-				return false
-			}
-			// Cast / Extract claims
-			jwt_claims := request.Env["JWT_PAYLOAD"].(map[string]interface{})
+			jwt_claims := ExtractClaims(request)
 
 			// Check the actual claim, set in PayloadFunc
 			return (jwt_claims["testkey"] == "testval")


### PR DESCRIPTION
I initially went back and forth on how to implement this:

``` go
func ExtractClaimsMethod1(request *rest.Request) (map[string]interface{}, error) {
  if request.Env["JWT_PAYLOAD"] == nil {
    return nil, fmt.Errorf("No JWT_PLAYLOAD")
  }
  jwt_claims := request.Env["JWT_PAYLOAD"].(map[string]interface{})
  return jwt_claims, nil
}
func ExtractClaimsMethod2(request *rest.Request) map[string]interface{} {
  if request.Env["JWT_PAYLOAD"] == nil {
    empty_claims := make(map[string]interface{})
    return empty_claims
  }
  jwt_claims := request.Env["JWT_PAYLOAD"].(map[string]interface{})
  return jwt_claims
}
```

In the end I settled on a combo of the two (as seen in the PR) which returns an
empty `map[string]interface{}` that allows you to ignore the returned `err` unless 
you really need to know that the claims were not set. 

If you don't need to know that the claims were not set that allows a more 
"every day" type of approach to be taken:

``` go
endpoint := func(w rest.ResponseWriter, r *rest.Request) {
  claims, _ := jwt.ExtractClaims(r)
  if claims["isAdmin"]==true {
    log.Println("You sir, are an admin")
  }
  w.WriteJson(...)
}
```

I also updated the `TestClaimsDuringAuthorization` test submitted in #4 to use 
the new `ExtractClaims` method to provide  some debugging info if the test 
fails due to missing claims.  Notice the first line of output.

```
$ go test
2015/05/20 13:08:32 JWT Claims Extraction failed during Authorization: No JWT_PLAYLOAD
--- FAIL: TestClaimsDuringAuthorization (0.00s)
        util.go:41: Code 200 expected, got: 401
FAIL
exit status 1
FAIL    github.com/StephanDollberg/go-json-rest-middleware-jwt  0.009s
```
