### PR TITLE
check if token is still refreshable

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -189,7 +189,15 @@ func (mw *JWTMiddleware) RefreshHandler(writer rest.ResponseWriter, request *res
 	token, err := mw.parseToken(request)
 
 	// Token should be valid anyway as the RefreshHandler is authed
-	if err != nil {
+	// But we should check if token is still refreshable:
+	// Allowed error is jwt.ValidationErrorExpired, jwt.ValidationErrorNotValidYet means token is completely outdated
+	switch err.(type){
+	case *jwt.ValidationError:
+		if err.(*jwt.ValidationError).Errors != jwt.ValidationErrorExpired {
+			mw.unauthorized(writer)
+			return
+		}
+	default:
 		mw.unauthorized(writer)
 		return
 	}


### PR DESCRIPTION
we should check if token is still refreshable:
Allowed error is jwt.ValidationErrorExpired, jwt.ValidationErrorNotValidYet means token is completely outdated
