### PR TITLE
Check if token is still refreshable

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -189,7 +189,15 @@ func (mw *JWTMiddleware) RefreshHandler(writer rest.ResponseWriter, request *res
 	token, err := mw.parseToken(request)
 
 	// Token should be valid anyway as the RefreshHandler is authed
-	if err != nil {
+	switch err.(type){
+	case *jwt.ValidationError:
+		if err.(*jwt.ValidationError).Errors != jwt.ValidationErrorExpired {
+			mw.unauthorized(writer)
+			return
+		}
+	case nil:
+		break
+	default:
 		mw.unauthorized(writer)
 		return
 	}

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -189,6 +189,13 @@ func (mw *JWTMiddleware) RefreshHandler(writer rest.ResponseWriter, request *res
 	token, err := mw.parseToken(request)
 
 	// Token should be valid anyway as the RefreshHandler is authed
+	// If we have *jwt.ValidationError and the only error is jwt.ValidationErrorExpired
+	//   -> that means that token is still valid and refreshable, just expired
+	//      -> that means we should contitue and perform refresh action
+	// If error is nil
+	//  -> that means everything is fine, proceed
+	// If some other error occured (say, invalid token)
+	//  -> then return 401
 	switch err.(type){
 	case *jwt.ValidationError:
 		if err.(*jwt.ValidationError).Errors != jwt.ValidationErrorExpired {


### PR DESCRIPTION
**MaxRefresh** time means :
- _that the maximum validity timespan for a token is MaxRefresh + Timeout_, 

but `RefreshHandler` returns 401 right after expiration of the **Timeout** so it makes no sense to specify **MaxRefresh** because anyway client well be rejected.

In this PR I did proper error handling which allows to refresh token if error is `jwt.ValidationErrorExpired`
