### PR TITLE
Add support for public and private keys

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -26,7 +26,10 @@ type Middleware struct {
 	SigningAlgorithm string
 
 	// Secret key used for signing. Required.
-	Key []byte
+	Key interface{}
+
+	// Secret key used for signing. Required.
+	VerifyKey interface{}
 
 	// Duration that a jwt token is valid. Optional, defaults to one hour.
 	Timeout time.Duration
@@ -178,6 +181,9 @@ func (mw *Middleware) parseToken(request *rest.Request) (*jwt.Token, error) {
 	return jwt.Parse(parts[1], func(token *jwt.Token) (interface{}, error) {
 		if jwt.GetSigningMethod(mw.SigningAlgorithm) != token.Method {
 			return nil, errors.New("Invalid signing algorithm")
+		}
+		if mw.VerifyKey != nil {
+			return mw.VerifyKey, nil
 		}
 		return mw.Key, nil
 	})

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -179,6 +179,7 @@ func (mw *Middleware) parseToken(request *rest.Request) (*jwt.Token, error) {
 	if !(len(parts) == 2 && parts[0] == "Bearer") {
 		return nil, errors.New("Invalid auth header")
 	}
+	request.Env["JWT_RAW"] = parts[1]
 
 	return jwt.Parse(parts[1], func(token *jwt.Token) (interface{}, error) {
 		if jwt.GetSigningMethod(mw.SigningAlgorithm) != token.Method {

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -67,9 +67,6 @@ func (mw *Middleware) MiddlewareFunc(handler rest.HandlerFunc) rest.HandlerFunc 
 	if mw.SigningAlgorithm == "" {
 		mw.SigningAlgorithm = "HS256"
 	}
-	if mw.Key == nil {
-		log.Fatal("Key required")
-	}
 	if mw.Timeout == 0 {
 		mw.Timeout = time.Hour
 	}

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -82,14 +82,15 @@ func (mw *Middleware) MiddlewareFunc(handler rest.HandlerFunc) rest.HandlerFunc 
 		}
 	}
 
-	return func(writer rest.ResponseWriter, request *rest.Request) { mw.middlewareImpl(writer, request, handler) }
+	return func(writer rest.ResponseWriter, request *rest.Request) {
+		mw.middlewareImpl(writer, request, handler)
+	}
 }
 
 func (mw *Middleware) middlewareImpl(writer rest.ResponseWriter, request *rest.Request, handler rest.HandlerFunc) {
 	token, err := mw.parseToken(request)
 
 	if err != nil {
-		log.Println(err)
 		mw.unauthorized(writer, err)
 		return
 	}
@@ -134,14 +135,12 @@ func (mw *Middleware) LoginHandler(writer rest.ResponseWriter, request *rest.Req
 	err := request.DecodeJsonPayload(&loginVals)
 
 	if err != nil {
-		log.Println(err)
 		mw.unauthorized(writer, err)
 		return
 	}
 
 	err = mw.Authenticator(loginVals.Username, loginVals.Password)
 	if err != nil {
-		log.Println(err)
 		mw.unauthorized(writer, err)
 		return
 	}
@@ -162,7 +161,6 @@ func (mw *Middleware) LoginHandler(writer rest.ResponseWriter, request *rest.Req
 	tokenString, err := token.SignedString(mw.Key)
 
 	if err != nil {
-		log.Println(err)
 		mw.unauthorized(writer, err)
 		return
 	}
@@ -205,7 +203,6 @@ func (mw *Middleware) RefreshHandler(writer rest.ResponseWriter, request *rest.R
 
 	// Token should be valid anyway as the RefreshHandler is authed
 	if err != nil {
-		log.Println(err)
 		mw.unauthorized(writer, err)
 		return
 	}
@@ -229,7 +226,6 @@ func (mw *Middleware) RefreshHandler(writer rest.ResponseWriter, request *rest.R
 	tokenString, err := newToken.SignedString(mw.Key)
 
 	if err != nil {
-		log.Println(err)
 		mw.unauthorized(writer, err)
 		return
 	}


### PR DESCRIPTION
I added support for public and private keys so that it can use ecdsa and rsa signing and verifying.

Also I renamed it to Middleware because it is already called from other packages as jwt.JWTMiddleware so I didn't see much reason to say JWT twice.
