### PR TITLE
StoreToken introduced + a token is written to request.Env to be able …

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -51,7 +51,7 @@ type JWTMiddleware struct {
 	StoreToken func(timeout time.Duration) func(username, token string)
 
 	// Remove token when refreshing/logging out
-	RemoveToken func(token string)
+	RemoveToken func(userId, token string)
 
 	// Callback function that will be called during login.
 	// Using this function it is possible to add additional payload data to the webtoken.
@@ -275,12 +275,14 @@ func (mw *JWTMiddleware) RefreshHandler(writer rest.ResponseWriter, request *res
 		return
 	}
 
+	userId := newToken.Claims["id"].(string)
+
 	if mw.StoreToken != nil {
-		mw.StoreToken(mw.Timeout)(newToken.Claims["id"].(string), tokenString)
+		mw.StoreToken(mw.Timeout)(userId, tokenString)
 	}
 
 	if mw.RemoveToken != nil {
-		mw.RemoveToken(token.Raw)
+		mw.RemoveToken(userId, token.Raw)
 	}
 
 	mw.RefreshCallback(tokenString, request, writer)

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -48,7 +48,7 @@ type JWTMiddleware struct {
 
 	// Callback function to store a token in case you want to have it checked within Authorizator in some sort of
 	// database as an additional security measure
-	StoreToken func(username, token string)
+	StoreToken func(timeout time.Duration) func(username, token string)
 
 	// Callback function that will be called during login.
 	// Using this function it is possible to add additional payload data to the webtoken.
@@ -165,7 +165,7 @@ func (mw *JWTMiddleware) LoginHandler(writer rest.ResponseWriter, request *rest.
 	}
 
 	if mw.StoreToken != nil {
-		mw.StoreToken(loginVals.Username, tokenString)
+		mw.StoreToken(mw.Timeout)(loginVals.Username, tokenString)
 	}
 
 	writer.WriteJson(resultToken{Token: tokenString})
@@ -227,7 +227,7 @@ func (mw *JWTMiddleware) RefreshHandler(writer rest.ResponseWriter, request *res
 	}
 
 	if mw.StoreToken != nil {
-		mw.StoreToken(newToken.Claims["id"].(string), tokenString)
+		mw.StoreToken(mw.Timeout)(newToken.Claims["id"].(string), tokenString)
 	}
 
 	writer.WriteJson(resultToken{Token: tokenString})


### PR DESCRIPTION
…to use it in the Authorizator

I'd needed that hook to support checking these tokens against Redis or any other storage. 
If you find that viable for your product - feel free to merge. In my opinion extra hook does not hurt. 
That's what I've been missing in a lot of middlewares, yours is almost perfect for my needs.
