### PR TITLE
Return unauthorized rather than 500 when id claim not specified

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -90,7 +90,14 @@ func (mw *JWTMiddleware) middlewareImpl(writer rest.ResponseWriter, request *res
 		return
 	}
 
-	id := token.Claims["id"].(string)
+	idInterface := token.Claims["id"]
+
+	if idInterface == nil {
+		mw.unauthorized(writer)
+		return
+	}
+
+	id := idInterface.(string)
 
 	request.Env["REMOTE_USER"] = id
 	request.Env["JWT_PAYLOAD"] = token.Claims

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -108,6 +108,17 @@ func TestAuthJWT(t *testing.T) {
 	recorded.CodeIs(401)
 	recorded.ContentTypeIsJson()
 
+	// right credt, right method, right priv key but no id
+	tokenNoId := jwt.New(jwt.GetSigningMethod("HS256"))
+	tokenNoId.Claims["exp"] = time.Now().Add(time.Hour).Unix()
+	tokenNoIdString, _ := tokenNoId.SignedString(key)
+
+	noIDReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
+	noIDReq.Header.Set("Authorization", "Bearer "+tokenNoIdString)
+	recorded = test.RunRequest(t, handler, noIDReq)
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
 	// right credt, right method, right priv, wrong signing method on request
 	tokenBadSigning := jwt.New(jwt.GetSigningMethod("HS384"))
 	tokenBadSigning.Claims["id"] = "admin"


### PR DESCRIPTION
Providing a token without an ID claim caused a panic / 500. Confused me a fair bit. Put in a test and some implementation to return 401 when that is the case.

In terms of easily consuming the middleware in other projects, would it be possible to put on reasons for the 401s in the response? Or is that being avoided for security reasons?
