### PR TITLE
Update version of jwt-go

### DIFF
--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -91,6 +91,13 @@ func (mw *JWTMiddleware) middlewareImpl(writer rest.ResponseWriter, request *res
 	}
 
 	claims := token.Claims.(jwt.MapClaims)
+	err = claims.Valid()
+
+	if err != nil {
+		mw.unauthorized(writer)
+		return
+	}
+
 	idInterface := claims["id"]
 
 	if idInterface == nil {
@@ -114,10 +121,10 @@ func (mw *JWTMiddleware) middlewareImpl(writer rest.ResponseWriter, request *res
 // ExtractClaims allows to retrieve the payload
 func ExtractClaims(request *rest.Request) map[string]interface{} {
 	if request.Env["JWT_PAYLOAD"] == nil {
-		emptyClaims := make(map[string]interface{})
+		emptyClaims := make(jwt.MapClaims)
 		return emptyClaims
 	}
-	jwtClaims := request.Env["JWT_PAYLOAD"].(map[string]interface{})
+	jwtClaims := request.Env["JWT_PAYLOAD"].(jwt.MapClaims)
 	return jwtClaims
 }
 

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -91,12 +91,6 @@ func (mw *JWTMiddleware) middlewareImpl(writer rest.ResponseWriter, request *res
 	}
 
 	claims := token.Claims.(jwt.MapClaims)
-	err = claims.Valid()
-
-	if err != nil {
-		mw.unauthorized(writer)
-		return
-	}
 
 	idInterface := claims["id"]
 

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -19,9 +19,10 @@ type DecoderToken struct {
 
 func makeTokenString(username string, key []byte) string {
 	token := jwt.New(jwt.GetSigningMethod("HS256"))
-	token.Claims["id"] = username
-	token.Claims["exp"] = time.Now().Add(time.Hour).Unix()
-	token.Claims["orig_iat"] = time.Now().Unix()
+	claims := token.Claims.(jwt.MapClaims)
+	claims["id"] = username
+	claims["exp"] = time.Now().Add(time.Hour).Unix()
+	claims["orig_iat"] = time.Now().Unix()
 	tokenString, _ := token.SignedString(key)
 	return tokenString
 }
@@ -98,8 +99,9 @@ func TestAuthJWT(t *testing.T) {
 
 	// right credt, right method, right priv key but timeout
 	token := jwt.New(jwt.GetSigningMethod("HS256"))
-	token.Claims["id"] = "admin"
-	token.Claims["exp"] = 0
+	tokenClaims := token.Claims.(jwt.MapClaims)
+	tokenClaims["id"] = "admin"
+	tokenClaims["exp"] = 0
 	tokenString, _ := token.SignedString(key)
 
 	expiredTimestampReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
@@ -110,7 +112,8 @@ func TestAuthJWT(t *testing.T) {
 
 	// right credt, right method, right priv key but no id
 	tokenNoId := jwt.New(jwt.GetSigningMethod("HS256"))
-	tokenNoId.Claims["exp"] = time.Now().Add(time.Hour).Unix()
+	tokenNoIdClaims := tokenNoId.Claims.(jwt.MapClaims)
+	tokenNoIdClaims["exp"] = time.Now().Add(time.Hour).Unix()
 	tokenNoIdString, _ := tokenNoId.SignedString(key)
 
 	noIDReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
@@ -121,8 +124,9 @@ func TestAuthJWT(t *testing.T) {
 
 	// right credt, right method, right priv, wrong signing method on request
 	tokenBadSigning := jwt.New(jwt.GetSigningMethod("HS384"))
-	tokenBadSigning.Claims["id"] = "admin"
-	tokenBadSigning.Claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
+	tokenBadSigningClaims := tokenBadSigning.Claims.(jwt.MapClaims)
+	tokenBadSigningClaims["id"] = "admin"
+	tokenBadSigningClaims["exp"] = time.Now().Add(time.Hour * 72).Unix()
 	tokenBadSigningString, _ := tokenBadSigning.SignedString(key)
 
 	BadSigningReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
@@ -188,8 +192,9 @@ func TestAuthJWT(t *testing.T) {
 		t.Errorf("Received new token with wrong signature", err)
 	}
 
-	if newToken.Claims["id"].(string) != "admin" ||
-		int64(newToken.Claims["exp"].(float64)) < before {
+	newTokenClaims := newToken.Claims.(jwt.MapClaims)
+	if newTokenClaims["id"].(string) != "admin" ||
+		int64(newTokenClaims["exp"].(float64)) < before {
 		t.Errorf("Received new token with wrong data")
 	}
 
@@ -199,10 +204,11 @@ func TestAuthJWT(t *testing.T) {
 
 	// refresh with expired max refresh
 	unrefreshableToken := jwt.New(jwt.GetSigningMethod("HS256"))
-	unrefreshableToken.Claims["id"] = "admin"
+	unrefreshableTokenClaims := unrefreshableToken.Claims.(jwt.MapClaims)
+	unrefreshableTokenClaims["id"] = "admin"
 	// the combination actually doesn't make sense but is ok for the test
-	unrefreshableToken.Claims["exp"] = time.Now().Add(time.Hour).Unix()
-	unrefreshableToken.Claims["orig_iat"] = 0
+	unrefreshableTokenClaims["exp"] = time.Now().Add(time.Hour).Unix()
+	unrefreshableTokenClaims["orig_iat"] = 0
 	tokenString, _ = unrefreshableToken.SignedString(key)
 
 	unrefreshableReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
@@ -213,11 +219,12 @@ func TestAuthJWT(t *testing.T) {
 
 	// valid refresh
 	refreshableToken := jwt.New(jwt.GetSigningMethod("HS256"))
-	refreshableToken.Claims["id"] = "admin"
+	refreshableTokenClaims := refreshableToken.Claims.(jwt.MapClaims)
+	refreshableTokenClaims["id"] = "admin"
 	// we need to substract one to test the case where token is being created in
 	// the same second as it is checked -> < wouldn't fail
-	refreshableToken.Claims["exp"] = time.Now().Add(time.Hour).Unix() - 1
-	refreshableToken.Claims["orig_iat"] = time.Now().Unix() - 1
+	refreshableTokenClaims["exp"] = time.Now().Add(time.Hour).Unix() - 1
+	refreshableTokenClaims["orig_iat"] = time.Now().Unix() - 1
 	tokenString, _ = refreshableToken.SignedString(key)
 
 	validRefreshReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
@@ -236,9 +243,10 @@ func TestAuthJWT(t *testing.T) {
 		t.Errorf("Received refreshed token with wrong signature", err)
 	}
 
-	if refreshToken.Claims["id"].(string) != "admin" ||
-		int64(refreshToken.Claims["orig_iat"].(float64)) != refreshableToken.Claims["orig_iat"].(int64) ||
-		int64(refreshToken.Claims["exp"].(float64)) < refreshableToken.Claims["exp"].(int64) {
+	refreshTokenClaims := refreshToken.Claims.(jwt.MapClaims)
+	if refreshTokenClaims["id"].(string) != "admin" ||
+		int64(refreshTokenClaims["orig_iat"].(float64)) != refreshTokenClaims["orig_iat"].(int64) ||
+		int64(refreshTokenClaims["exp"].(float64)) < refreshTokenClaims["exp"].(int64) {
 		t.Errorf("Received refreshed token with wrong data")
 	}
 }
@@ -283,7 +291,8 @@ func TestAuthJWTPayload(t *testing.T) {
 		t.Errorf("Received new token with wrong signature", err)
 	}
 
-	if newToken.Claims["testkey"].(string) != "testval" || newToken.Claims["exp"].(float64) == 0 {
+	newTokenClaims := newToken.Claims.(jwt.MapClaims)
+	if newTokenClaims["testkey"].(string) != "testval" || newTokenClaims["exp"].(float64) == 0 {
 		t.Errorf("Received new token without payload")
 	}
 
@@ -293,10 +302,11 @@ func TestAuthJWTPayload(t *testing.T) {
 	refreshApi.SetApp(rest.AppSimple(authMiddleware.RefreshHandler))
 
 	refreshableToken := jwt.New(jwt.GetSigningMethod("HS256"))
-	refreshableToken.Claims["id"] = "admin"
-	refreshableToken.Claims["exp"] = time.Now().Add(time.Hour).Unix()
-	refreshableToken.Claims["orig_iat"] = time.Now().Unix()
-	refreshableToken.Claims["testkey"] = "testval"
+	refreshableTokenClaims := refreshableToken.Claims.(jwt.MapClaims)
+	refreshableTokenClaims["id"] = "admin"
+	refreshableTokenClaims["exp"] = time.Now().Add(time.Hour).Unix()
+	refreshableTokenClaims["orig_iat"] = time.Now().Unix()
+	refreshableTokenClaims["testkey"] = "testval"
 	tokenString, _ := refreshableToken.SignedString(key)
 
 	validRefreshReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
@@ -315,7 +325,8 @@ func TestAuthJWTPayload(t *testing.T) {
 		t.Errorf("Received refreshed token with wrong signature", err)
 	}
 
-	if refreshToken.Claims["testkey"].(string) != "testval" {
+	refreshTokenClaims := refreshToken.Claims.(jwt.MapClaims)
+	if refreshTokenClaims["testkey"].(string) != "testval" {
 		t.Errorf("Received new token without payload")
 	}
 
@@ -328,10 +339,11 @@ func TestAuthJWTPayload(t *testing.T) {
 	}))
 
 	payloadToken := jwt.New(jwt.GetSigningMethod("HS256"))
-	payloadToken.Claims["id"] = "admin"
-	payloadToken.Claims["exp"] = time.Now().Add(time.Hour).Unix()
-	payloadToken.Claims["orig_iat"] = time.Now().Unix()
-	payloadToken.Claims["testkey"] = "testval"
+	payloadTokenClaims := payloadToken.Claims.(jwt.MapClaims)
+	payloadTokenClaims["id"] = "admin"
+	payloadTokenClaims["exp"] = time.Now().Add(time.Hour).Unix()
+	payloadTokenClaims["orig_iat"] = time.Now().Unix()
+	payloadTokenClaims["testkey"] = "testval"
 	payloadTokenString, _ := payloadToken.SignedString(key)
 
 	payloadReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -101,7 +101,7 @@ func TestAuthJWT(t *testing.T) {
 	token := jwt.New(jwt.GetSigningMethod("HS256"))
 	tokenClaims := token.Claims.(jwt.MapClaims)
 	tokenClaims["id"] = "admin"
-	tokenClaims["exp"] = 0
+	tokenClaims["exp"] = 1
 	tokenString, _ := token.SignedString(key)
 
 	expiredTimestampReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
@@ -245,8 +245,8 @@ func TestAuthJWT(t *testing.T) {
 
 	refreshTokenClaims := refreshToken.Claims.(jwt.MapClaims)
 	if refreshTokenClaims["id"].(string) != "admin" ||
-		int64(refreshTokenClaims["orig_iat"].(float64)) != refreshTokenClaims["orig_iat"].(int64) ||
-		int64(refreshTokenClaims["exp"].(float64)) < refreshTokenClaims["exp"].(int64) {
+		int64(refreshTokenClaims["orig_iat"].(float64)) != refreshableTokenClaims["orig_iat"].(int64) ||
+		int64(refreshTokenClaims["exp"].(float64)) < refreshableTokenClaims["exp"].(int64) {
 		t.Errorf("Received refreshed token with wrong data")
 	}
 }
@@ -334,7 +334,7 @@ func TestAuthJWTPayload(t *testing.T) {
 	payloadApi := rest.NewApi()
 	payloadApi.Use(authMiddleware)
 	payloadApi.SetApp(rest.AppSimple(func(w rest.ResponseWriter, r *rest.Request) {
-		testval := r.Env["JWT_PAYLOAD"].(map[string]interface{})["testkey"].(string)
+		testval := r.Env["JWT_PAYLOAD"].(jwt.MapClaims)["testkey"].(string)
 		w.WriteJson(map[string]string{"testkey": testval})
 	}))
 


### PR DESCRIPTION
Don't know if you want to use this or not. I've updated the version of jwt-go to the latest. I was having dependency clashes in my project so needed it to reference latest jwt-go.

The biggest change was that claims was no longer a `map[string]interface{}`, so had to use the MapClaims type provided.

There was also a change in the way it validates expiry time, essentially treating a 0 value as if the claim wasn't specified. The test was previously using a zero value to test for a failed expiry, so i have adjusted that to pass up a value of 1 instead. 
